### PR TITLE
Issue_3: Support reading V2 bag files larger than 2 GB

### DIFF
--- a/RobSharper.Ros.BagReader.Tests/BagReaderTests.cs
+++ b/RobSharper.Ros.BagReader.Tests/BagReaderTests.cs
@@ -29,9 +29,12 @@ namespace RobSharper.Ros.BagReader.Tests
         public void Can_read_bag(string bagfile)
         {
             SetBagFile(bagfile);
-            
-            var rosbag = BagReaderFactory.Create(_bagStream, RecordVisitor.NullVisitor);
+
+            var visitorMock = new Mock<IBagRecordVisitor>();
+            var rosbag = BagReaderFactory.Create(_bagStream, visitorMock.Object);
             rosbag.ProcessAll();
+
+            visitorMock.Verify(x => x.Visit(It.IsAny<Chunk>()), Times.AtLeastOnce());
         }
 
 

--- a/RobSharper.Ros.BagReader/V2BagReader.cs
+++ b/RobSharper.Ros.BagReader/V2BagReader.cs
@@ -69,7 +69,7 @@ namespace RobSharper.Ros.BagReader
 
         private RosBinaryReader CreateRecordDataReader()
         {
-            var length = _reader.ReadInt32();
+            var length = _reader.ReadUInt32();
             var confinedStream = new ConfinedReadOnlyStream(_stream, length);
             var dataReader = new RosBinaryReader(confinedStream);
 


### PR DESCRIPTION
Added a test that failed on a 4 GB rosbag (did not include due to size) and updated code to pass the test locally.